### PR TITLE
SA-102 Removing alignment property from table properties dialog

### DIFF
--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -341,29 +341,7 @@
 								else
 									selectedTable.removeAttribute( 'border' );
 							}
-						},
-						{
-							id: 'cmbAlign',
-							type: 'select',
-							requiredContent: 'table[align]',
-							'default': '',
-							label: editor.lang.common.align,
-							items: [
-								[ editor.lang.common.notSet, '' ],
-								[ editor.lang.common.alignLeft, 'left' ],
-								[ editor.lang.common.alignCenter, 'center' ],
-								[ editor.lang.common.alignRight, 'right' ]
-							],
-							setup: function( selectedTable ) {
-								this.setValue( selectedTable.getAttribute( 'align' ) || '' );
-							},
-							commit: function( data, selectedTable ) {
-								if ( this.getValue() )
-									selectedTable.setAttribute( 'align', this.getValue() );
-								else
-									selectedTable.removeAttribute( 'align' );
-							}
-						} ]
+						}]
 					},
 					{
 						type: 'vbox',


### PR DESCRIPTION
If the alignment property gets set, the item gives a JAXBE schema error saying that the alignment property cannot be set on table elements, according to the QTI schema.
Will need to update the commit hash for ckeditor in qti-jq after this pull request.