### PR TITLE
SA-47517 removing this hidpi specific css in our pds skin

### DIFF
--- a/skins/pds/editor.css
+++ b/skins/pds/editor.css
@@ -1396,9 +1396,6 @@ legend.cke_voice_label {
 	background: url(icons_hidpi.png) no-repeat 0 -1080px !important;
 	background-size: 16px !important;
 }
-.cke_hidpi .cke_button__oembed_icon {
-	background: url(icons_hidpi.png) no-repeat 0 -1104px !important;
-}
 .cke_chrome,
 .cke_top,
 .cke_toolgroup,


### PR DESCRIPTION
The icon expected here is not built for this hidpi specific css, and causes an issue on hidpi screens.